### PR TITLE
Remove whitespace from the begining of templates

### DIFF
--- a/kickstart/recipes/kickstart/stream.sh
+++ b/kickstart/recipes/kickstart/stream.sh
@@ -4,6 +4,6 @@ kickstart.stream.contains() {
 
 kickstart.stream.template() {
   eval "cat <<KICKSTART
-  $(cat)
+$(cat)
 KICKSTART"
 }


### PR DESCRIPTION
kickstart templates are always putting a whitespace on the begining of the file, this commit fixes it

![captura de tela 2015-09-25 as 09 36 03](https://cloud.githubusercontent.com/assets/792201/10100555/f379c466-6368-11e5-8371-fca80a895e70.png)