### PR TITLE
Remove double quotes from ssh target

### DIFF
--- a/lib/kickstart-deploy
+++ b/lib/kickstart-deploy
@@ -23,4 +23,4 @@ CMD
 )
 
 kickstart compile "$@"
-tar chz -C compile . | ssh "$target" "$remote_command"
+tar chz -C compile . | ssh $target "$remote_command"


### PR DESCRIPTION
I wasn't able to pass a custom port because of the quotes, it wouldn't consider the `-p` as an option, instead it was considering it as part of the url, like in `ssh "my@server -p 2222"`